### PR TITLE
12.20和16.7实际测试报错，进行修复

### DIFF
--- a/excersize/ch12.md
+++ b/excersize/ch12.md
@@ -544,6 +544,8 @@ private:
 
 class StrBlobPtr
 {
+	friend bool operator==(const StrBlobPtr&,const StrBlobPtr&);
+    	friend bool operator!=(const StrBlobPtr&,const StrBlobPtr&);
 public:
 	StrBlobPtr() :curr(0) {}
 	StrBlobPtr(StrBlob &a, size_t sz = 0) :wptr(a.data), curr(sz) {}
@@ -579,6 +581,17 @@ StrBlobPtr StrBlob::begin()
 StrBlobPtr StrBlob::end()
 {
 	return StrBlobPtr(*this, data->size());
+}
+
+bool operator==(const StrBlobPtr& lhs, const StrBlobPtr& rhs) {
+    if (!lhs.wptr.expired() && !rhs.wptr.expired()) {
+        return (lhs.wptr.lock() == rhs.wptr.lock()) && (lhs.curr == rhs.curr);
+    } else {
+        return false;
+    }
+}
+bool operator!=(const StrBlobPtr& lhs, const StrBlobPtr& rhs) {
+    return !(lhs==rhs);
 }
 ```
 

--- a/excersize/ch16.md
+++ b/excersize/ch16.md
@@ -88,7 +88,7 @@ T* end(const T (&arr)[N])
 解：
 
 ```cpp
-template<typename T, typename N> constexpr
+template<typename T, unsigned N> constexpr
 unsigned size(const T (&arr)[N])
 {
 	return N;


### PR DESCRIPTION
练习12.20中，sbp != sb.end()报错，原因是无法对两个StrBlobPtr进行默认的 != 操作，需要对这个运算符进行重载。

练习16.7中，N应用在 const T (&arr)[N] 中，这时N的类型只能是表示数组长度的size_t，也就是unsigned类型，这里可以写size_t也可以写unsigned。